### PR TITLE
0, 0에 한글이 없어도 아래로 이동하도록 수정

### DIFF
--- a/aheui.c
+++ b/aheui.c
@@ -199,7 +199,7 @@ void input(FILE *fp) {
 
 int execute() {
     int x = 0, y = 0;
-    struct dir dir;
+    struct dir dir = {0, 1};
     int step = 0;
 
 #ifdef DEBUG
@@ -209,11 +209,17 @@ int execute() {
 #endif
         int a, b;
         struct opcode *cell = &space[y][x];
-        if (cell->flags & FLAG_DIR_SET) dir = cell->dir;
+        if (cell->flags & FLAG_DIR_SET) {
+            dir = cell->dir;
+        }
         else {
             // FLAG_DIR_SET and FLAG_DIR_FLIP* are mutually exclusive
-            if (cell->flags & FLAG_DIR_FLIPX) dir.dx = -dir.dx;
-            if (cell->flags & FLAG_DIR_FLIPY) dir.dy = -dir.dy;
+            if (cell->flags & FLAG_DIR_FLIPX) {
+                dir.dx = -dir.dx;
+            }
+            if (cell->flags & FLAG_DIR_FLIPY) {
+                 dir.dy = -dir.dy;
+            }
         }
         if ((cell->flags & MASK_REQ_ELEMS) != 0) {
             if (current_stack != 21) {


### PR DESCRIPTION
관련 표준: 커서는 코드 공간의 맨 첫 줄 맨 첫번째 칸에서 시작합니다. 맨 처음에 홀소리가 없을 경우 커서는 기본값으로 아랫쪽으로 이동하는데, 이는 #!과 호환시키기 위한 것으로, 기본 방향이 오른쪽인 funge와는 다른 점입니다.
