### PR TITLE
정수 입력이 다음 문자 입력을 공백으로 오염시키는 문제 수정

### DIFF
--- a/aheui.c
+++ b/aheui.c
@@ -265,7 +265,7 @@ int execute(int *exitcode) {
             case OP_INPUT_NUM:
                 if (!quiet_mode)
                     fprintf(stderr, "Input number: ");
-                scanf("%d", &a);
+                scanf("%d ", &a);
                 push(a);
             break;
             case OP_INPUT_CHAR:


### PR DESCRIPTION
이 동작은 아희의 표준으로 명시된 것은 아니지만 scanf에서 다른 문자 입력 추가를 피하면서 공백 입력 없이 숫자를 입력 받을 방법이 없기 때문에 공백을 다음 문자 입력에 포함시키지 않는 것이 더 합리적인 것으로 보입니다.
