### PR TITLE
Fix wrong behaviour of queue on duplication

### DIFF
--- a/aheui.c
+++ b/aheui.c
@@ -286,8 +286,10 @@ int execute(int *exitcode) {
                 if (current_stack != 21) {
                     push(a);
                 } else {
-                    if (queue_front == &stack[21][0]) // no space before front
-                        memmove(queue_front + 1, queue_front, current_stack_top - queue_front);
+                    if (queue_front == &stack[21][0]) { // no space before front
+                        memmove(queue_front + 2, queue_front + 1, current_stack_top - queue_front);
+                        current_stack_top = ++stack_top[21];
+                    }
                     *queue_front = a;
                     queue_front--;
                 }

--- a/aheui.c
+++ b/aheui.c
@@ -288,7 +288,7 @@ int execute(int *exitcode) {
                 } else {
                     if (queue_front == &stack[21][0]) { // no space before front
                         memmove(queue_front + 2, queue_front + 1, current_stack_top - queue_front);
-                        current_stack_top = ++stack_top[21];
+                        current_stack_top++;
                     }
                     *queue_front = a;
                     queue_front--;


### PR DESCRIPTION
The queue behavioured incorrectly on duplicate operation(as stated [here](https://www.acmicpc.net/board/view/2827)), which can be reproduced with this code: `상받빠빠망망망하`; the expected output is `333`, but `330` is printed.

This commit fixes the issue of the code moving values when there is no space to insert at front, as following:
1. The values start from `queue_front + 1`, not `queue_front`
2. `current_stack_top` should be increased as the contents are pushed back.
  